### PR TITLE
Make `firstLetter` method multibyte safe

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -12,7 +12,7 @@ class Str extends BaseStr
      */
     public static function firstLetter(string $value): string
     {
-        return substr($value, 0, 1);
+        return BaseStr::substr($value, 0, 1);
     }
 
     /**


### PR DESCRIPTION
Adopt Laravel's `substr` helper for multibyte safe support.

See: https://github.com/laravel/framework/blob/85a514632e410ae8f90c2b32c79a2788ba9d1076/src/Illuminate/Support/Str.php#L1370-L1382