### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.17",


### PR DESCRIPTION
## Summary
- Adds `^13.0` to `illuminate/contracts` and `illuminate/support` dependency constraints

## Notes
- No breaking changes in the package code — only constraint widening
- Laravel 13 upgrade guide: https://laravel.com/docs/13.x/upgrade